### PR TITLE
Change TagType labels of SourceTag

### DIFF
--- a/src/models/SourceTag/index.ts
+++ b/src/models/SourceTag/index.ts
@@ -14,9 +14,9 @@ export interface SourceTag {
  * Common colors are red for (Broken), yellow for (+18), grey for (Country-Proof)
  */
 export enum TagType {
-    BLUE = 'blue',
-    GREEN = 'green',
-    GREY = 'grey',
-    YELLOW = 'yellow',
-    RED = 'red'
+    BLUE = '',
+    GREEN = 'success',
+    GREY = 'info',
+    YELLOW = 'warning',
+    RED = 'danger'
 }

--- a/src/models/SourceTag/index.ts
+++ b/src/models/SourceTag/index.ts
@@ -10,11 +10,13 @@ export interface SourceTag {
 
 /**
  * An enumerator which {@link SourceTags} uses to define the color of the tag rendered on the website.
- * Info is blue, success is green, warning is yellow and danger is red.
+ * Five types are available: blue, green, grey, yellow and red, the default one is blue.
+ * Common colors are red for (Broken), yellow for (+18), grey for (Country-Proof)
  */
 export enum TagType {
-    WARNING = 'warning',
-    INFO = 'info',
-    SUCCESS = 'success',
-    DANGER = 'danger'
+    BLUE = 'blue',
+    GREEN = 'green',
+    GREY = 'grey',
+    YELLOW = 'yellow',
+    RED = 'red'
 }


### PR DESCRIPTION
This pull request add the default blue [Element tag](https://element.eleme.io/#/en-US/component/tag) type to the `TagType` enum.

It also change the type from `WARNING`, `DANGER`, `SUCCESS`, `INFO` to their respective colors: `RED`, `YELLOW`, `GREEN`, `GREY` and `BLUE`. 
I believe it would be easier to use the color of the intended tag instead of the label used in the website. A dictionary will do the conversion on the website side. 
This modification would also allow, for example, to not call languages `success` or other information `danger`.