### PR TITLE
Fix typo in the Language enum

### DIFF
--- a/src/models/Languages/index.ts
+++ b/src/models/Languages/index.ts
@@ -14,7 +14,7 @@ export enum LanguageCode {
     FRENCH = 'fr',
     WELSH = 'gb',
     GREEK = 'gr',
-    CHINEESE_HONGKONG = 'hk',
+    CHINESE_HONGKONG = 'hk',
     HUNGARIAN = 'hu',
     INDONESIAN = 'id',
     ISRELI = 'il',


### PR DESCRIPTION
The HongKong constant was named `CHINEESE_HONGKONG = "hk"`, where `CHINEESE` is a typo of `CHINESE`. This PR will fix this typo, but this does create a breaking change.